### PR TITLE
moved OkapiScriptEntryPointController and OkapiUrls to toplevel

### DIFF
--- a/okapi/OkapiScriptEntryPointController.php
+++ b/okapi/OkapiScriptEntryPointController.php
@@ -1,10 +1,9 @@
 <?php
 
-namespace okapi\lib;
+namespace okapi;
 
 use okapi\core\Exception\Http404;
 use okapi\core\Okapi;
-use okapi\core\OkapiUrls;
 use okapi\views\http404\View as Http404View;
 
 class OkapiScriptEntryPointController

--- a/okapi/OkapiUrls.php
+++ b/okapi/OkapiUrls.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace okapi\Core;
+namespace okapi;
 
 # This is the list of OKAPI views. Regexps are mapped to namespaces.
 # Each namespace should expose the Webservice class with a method "call".

--- a/okapi/index.php
+++ b/okapi/index.php
@@ -16,10 +16,11 @@
 # endpoint (this one!), then we need to set it up ourselves.
 #
 
+namespace okapi;
+
 use okapi\core\Exception\OkapiExceptionHandler;
 use okapi\core\Okapi;
 use okapi\core\OkapiErrorHandler;
-use okapi\lib\OkapiScriptEntryPointController;
 
 $GLOBALS['rootpath'] = __DIR__.'/../';
 


### PR DESCRIPTION
PR to PR :-)

Those two files belong to index.php, therfore I suggest to put them into the same directory. All other classes in "core" and "lib" are (also) included from services and views.