### PR TITLE
allow rootpath override (for OCDE composer integration)

### DIFF
--- a/okapi/index.php
+++ b/okapi/index.php
@@ -22,7 +22,8 @@ use okapi\core\Exception\OkapiExceptionHandler;
 use okapi\core\Okapi;
 use okapi\core\OkapiErrorHandler;
 
-$GLOBALS['rootpath'] = __DIR__.'/../';
+if (!isset($GLOBALS['rootpath']))
+    $GLOBALS['rootpath'] = __DIR__.'/../';
 
 require_once __DIR__ . '/autoload.php';
 


### PR DESCRIPTION
This change got lost. Okapi does not work without it.